### PR TITLE
lcitool: Fix 'architecture' typo

### DIFF
--- a/guests/lcitool/examples/manifest.yml
+++ b/guests/lcitool/examples/manifest.yml
@@ -70,7 +70,7 @@ gitlab:
 #
 #     The job dict contains
 #
-#       - "arch": an arcitecture name
+#       - "arch": an architecture name
 #       - "enabled": bool, to temporarily skip a target
 #       - "allow-failure": bool, to ignore job failures
 #       - "builds": bool, used to skip build job


### PR DESCRIPTION
Signed-off-by: Philippe Mathieu-Daudé <f4bug@amsat.org>